### PR TITLE
Adds automatic rename of the sqlite3 engine

### DIFF
--- a/pkg/database/db.go
+++ b/pkg/database/db.go
@@ -68,6 +68,13 @@ func Init(config *acmedns.AcmeDnsConfig, logger *zap.SugaredLogger) (acmedns.Acm
 	var d = &acmednsdb{Config: config, Logger: logger}
 	d.Mutex.Lock()
 	defer d.Mutex.Unlock()
+
+	if config.Database.Engine == "sqlite3" {
+		logger.Warn("DB: sqlite3 engine has been replaced by the sqlite engine. Please update your config")
+		config.Database.Engine = "sqlite"
+		logger.Info("DB: replacing sqlite3 engine with sqlite engine")
+	}
+
 	db, err := sql.Open(config.Database.Engine, config.Database.Connection)
 	if err != nil {
 		return d, err


### PR DESCRIPTION
Adds a warning when the deprecated sqlite3 database engine is used. Automatically replace the sqlite3 engine with the new sqlite engine